### PR TITLE
Chmod settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## ?.?.? (??? ??, 2017)
+
+IMPROVEMENTS:
+
+* Allow to specify chmod settings of local copy
+
 ## 0.2.2 (Jul 26, 2017)
 
 BUGFIXES:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ vaults:
 secrets:
   qa:
     lease_ttl: "1h"
+    mod: 0600
     mappings:
     - local: "local/path/to/qa-foo"
       vault: "secret/qa/qa-foo"
     - local: "local/path/to/qa-bar"
       vault: "secret/qa/qa-bar"
+      mod: 0755
 
   prod:
     mappings:

--- a/src/main/model.go
+++ b/src/main/model.go
@@ -31,10 +31,12 @@ type VaultAuth struct {
 type SecretGroup struct {
 	Mappings []SecretMapping `yaml:"mappings"`
 	LeaseTTL string          `yaml:"lease_ttl"`
+	Mod      int             `yaml:"mod"`
 }
 
 // SecretMapping ...
 type SecretMapping struct {
 	Local string `yaml:"local"`
 	Vault string `yaml:"vault"`
+	Mod   int    `yaml:"mod"`
 }

--- a/src/main/saidumlo.go
+++ b/src/main/saidumlo.go
@@ -91,8 +91,17 @@ func createDirIfMissing(path string) {
 /***************************
  * Vault interaction
  ***************************/
-func (vault *Vault) readSecretMapping(secretMapping SecretMapping) {
+func (vault *Vault) readSecretMapping(secretMapping SecretMapping, groupMod int) {
 	logInfo("%s read -field=value %s > %s/%s", vault.Bin, secretMapping.Vault, configDir, secretMapping.Local)
+
+	// determine file mod
+	var mod = 0755
+	if secretMapping.Mod != 0 {
+		mod = secretMapping.Mod
+	} else if groupMod != 0 {
+		mod = groupMod
+	}
+	secretFileMode := os.FileMode(mod)
 
 	createDirIfMissing(fmt.Sprintf("%s/%s", configDir, filepath.Dir(secretMapping.Local)))
 
@@ -100,6 +109,10 @@ func (vault *Vault) readSecretMapping(secretMapping SecretMapping) {
 	outfile, fileErr := os.Create(fmt.Sprintf("%s/%s", configDir, secretMapping.Local))
 	checkErr(fileErr)
 	defer outfile.Close()
+
+	// set file permissions
+	modErr := outfile.Chmod(secretFileMode)
+	checkErr(modErr)
 
 	env := os.Environ()
 	env = append(env, fmt.Sprintf("VAULT_ADDR=%s", vault.Address))
@@ -195,11 +208,12 @@ func (cwsg *CommandWithSecretGroups) processCommandWithSecretGroups(method strin
 
 	for _, secretGroupName := range groupsToProcess {
 		var leaseTTL = sdl.Config.SecretGroups[secretGroupName].LeaseTTL
+		var groupMod = sdl.Config.SecretGroups[secretGroupName].Mod
 		for _, secretMapping := range sdl.Config.SecretGroups[secretGroupName].Mappings {
 			if method == writeOperationID {
 				vault.writeSecretMapping(secretMapping, leaseTTL)
 			} else if method == readOperationID {
-				vault.readSecretMapping(secretMapping)
+				vault.readSecretMapping(secretMapping, groupMod)
 			} else {
 				logError("Unknown operation %s", method)
 			}

--- a/src/main/saidumlo.go
+++ b/src/main/saidumlo.go
@@ -95,7 +95,7 @@ func (vault *Vault) readSecretMapping(secretMapping SecretMapping, groupMod int)
 	logInfo("%s read -field=value %s > %s/%s", vault.Bin, secretMapping.Vault, configDir, secretMapping.Local)
 
 	// determine file mod
-	var mod = 0755
+	var mod = 0750 // default
 	if secretMapping.Mod != 0 {
 		mod = secretMapping.Mod
 	} else if groupMod != 0 {

--- a/test/prod-bar
+++ b/test/prod-bar
@@ -1,2 +1,0 @@
-test number
-1

--- a/test/test.config.yml
+++ b/test/test.config.yml
@@ -24,6 +24,7 @@ secrets:
    - local: "./qa-bar"
      vault: "secret/test/qa-bar"
  prod:
+   mod: 0740
    mappings:
    - local: "./create/prod-foo"
      vault: "secret/test/qa-foo"
@@ -31,3 +32,4 @@ secrets:
      vault: "secret/test/qa-bar"
    - local: "./create/many/levels/prod-fooo"
      vault: "secret/test/qa-foo"
+     mod: 0600

--- a/test/test.sh
+++ b/test/test.sh
@@ -10,6 +10,8 @@ bin/sdl -b testB -f ./test/test.config.yml read prod
 ##############
 # Check result
 #
+
+### File contents
 if ! diff -q test/qa-foo test/create/prod-foo &>/dev/null; then
    echo "Test failed!"
    exit 1
@@ -20,3 +22,13 @@ if ! diff -q test/qa-bar test/create2/many/levels/prod-bar &>/dev/null; then
    exit 1
 fi
 
+### File mods
+if [ $(stat -c "%a" test/create/many/levels/prod-fooo) -ne 600 ]; then
+    echo "test/create/many/levels/prod-fooo is $(stat -c "%a" test/create/many/levels/prod-fooo)"
+    exit 1
+fi
+
+if [ $(stat -c "%a" test/create/prod-foo) -ne 740 ]; then
+    echo "test/create/prod-foo is $(stat -c "%a" test/create/many/levels/prod-fooo)"
+    exit 1
+fi


### PR DESCRIPTION
Fixes #27 

This is useful if you read ssh keys, as by default ssh will complain when a key is world readable.